### PR TITLE
Improve Background Job Processing

### DIFF
--- a/src/Hangfire.Community.Outbox/Extensions/WebApplicationExtensions.cs
+++ b/src/Hangfire.Community.Outbox/Extensions/WebApplicationExtensions.cs
@@ -12,13 +12,23 @@ public static class WebApplicationExtensions
     public static void UseHangfireOutboxDashboard(this WebApplication app, string path = "/hangfireoutbox")
     {
 
-        app.MapGet(path, async (HttpContext context, [FromServices] IDbContextAccessor dbContextAccessor) =>
+        app.MapGet(path, async (
+            HttpContext context,
+            [FromServices] IDbContextAccessor dbContextAccessor,
+            [FromQuery] int? skip,
+            [FromQuery] int? take) =>
         {
+            var skipValue = skip.GetValueOrDefault(0);
+            var takeValue = take.GetValueOrDefault(1000);
+            if (skipValue < 0) skipValue = 0;
+            if (takeValue < 1) takeValue = 1000;
+
             var latest = await dbContextAccessor.GetDbContext()
                 .Set<OutboxJob>()
                 .AsNoTracking()
-                .Take(1000)
                 .OrderByDescending(x => x.CreatedOn)
+                .Skip(skipValue)
+                .Take(takeValue)
                 .Select(x => new { x.Id, x.HangfireJobId, x.JobType, x.MethodName, x.Queue, x.Exception, Status = x.HangfireJobId == null && x.Exception == null ? OutboxJobStatus.Pending : x.HangfireJobId != null ? OutboxJobStatus.Processed : OutboxJobStatus.Error })
                 .ToArrayAsync();
 

--- a/src/Hangfire.Community.Outbox/HostedServices/OutboxJobsProcessorBackgroundService.cs
+++ b/src/Hangfire.Community.Outbox/HostedServices/OutboxJobsProcessorBackgroundService.cs
@@ -1,31 +1,81 @@
 ﻿using Hangfire.Community.Outbox.Extensions;
 using Hangfire.Community.Outbox.Services;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Hangfire.Community.Outbox.HostedServices;
 
-public class OutboxJobsProcessorBackgroundService: BackgroundService
+public class OutboxJobsProcessorBackgroundService : BackgroundService
 {
     private readonly IOutboxProcessor _outboxProcessor;
     private readonly HangfireOutboxOptions _outboxOptions;
+    private readonly ILogger<OutboxJobsProcessorBackgroundService> _logger;
 
-    public OutboxJobsProcessorBackgroundService(IOutboxProcessor outboxProcessor, HangfireOutboxOptions outboxOptions)
+    // Backoff state
+    private static readonly TimeSpan MaxBackoff = TimeSpan.FromMinutes(2);
+    private TimeSpan _currentBackoff;
+
+    public OutboxJobsProcessorBackgroundService(
+        IOutboxProcessor outboxProcessor,
+        HangfireOutboxOptions outboxOptions,
+        ILogger<OutboxJobsProcessorBackgroundService> logger)
     {
         _outboxProcessor = outboxProcessor;
         _outboxOptions = outboxOptions;
+        _logger = logger;
+        _currentBackoff = outboxOptions.OutboxProcessorFrequency;
     }
-    
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        while (!stoppingToken.IsCancellationRequested)
+        _logger.LogInformation("Outbox processor started");
+
+        using var timer = new PeriodicTimer(_outboxOptions.OutboxProcessorFrequency);
+
+        // Run once immediately on startup, then on each tick
+        do
         {
-            await ProcessOutboxMessages(stoppingToken);    
-            await Task.Delay(_outboxOptions.OutboxProcessorFrequency, stoppingToken);
+            await ProcessOutboxMessages(stoppingToken);
         }
+        while (await timer.WaitForNextTickAsync(stoppingToken));
+
+        _logger.LogInformation("Outbox processor stopped");
     }
 
     private async Task ProcessOutboxMessages(CancellationToken stoppingToken)
     {
-        await _outboxProcessor.Process(stoppingToken);
+        try
+        {
+            await _outboxProcessor.Process(stoppingToken);
+
+            // Reset backoff on success
+            _currentBackoff = _outboxOptions.OutboxProcessorFrequency;
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Normal shutdown — don't log as error, just exit
+            _logger.LogDebug("Outbox processing cancelled during shutdown");
+        }
+        catch (Exception ex)
+        {
+            // Escalate backoff on failure: 2x each time up to MaxBackoff
+            _currentBackoff = TimeSpan.FromMilliseconds(
+                Math.Min(_currentBackoff.TotalMilliseconds * 2, MaxBackoff.TotalMilliseconds));
+
+            _logger.LogError(ex,
+                "Outbox processing failed. Backing off for {Backoff}s before next attempt",
+                _currentBackoff.TotalSeconds);
+
+            // Wait out the backoff before returning (so the PeriodicTimer
+            // tick we already consumed doesn't immediately re-trigger)
+            try
+            {
+                await Task.Delay(_currentBackoff, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Shutdown during backoff — fine
+            }
+        }
     }
 }

--- a/src/Hangfire.Community.Outbox/Services/OutboxProcessor.cs
+++ b/src/Hangfire.Community.Outbox/Services/OutboxProcessor.cs
@@ -21,14 +21,17 @@ public class OutboxProcessor: IOutboxProcessor
         _options = options;
     }
     
+    private const int ChunkSize = 100;
+    private const int MaxDegreeOfParallelism = 16;
+
     public async Task Process(CancellationToken ct)
     {
         using var scope = _serviceScopeFactory.CreateScope();
         var dbContextAccessor = scope.ServiceProvider.GetRequiredService<IDbContextAccessor>();
         await using var dbContext = dbContextAccessor.GetDbContext();
-        
+
         var backgroundJobClient = scope.ServiceProvider.GetRequiredService<IBackgroundJobClient>();
-        
+
         var toProcess = await dbContext.Set<OutboxJob>()
             .Where(x => !x.Processed && x.Exception == null)
             .OrderBy(x => x.CreatedOn)
@@ -39,56 +42,58 @@ public class OutboxProcessor: IOutboxProcessor
         {
             return;
         }
-        
+
         _logger.LogDebug("Processing {nbJobs} outbox jobs", toProcess.Length);
-        
-        foreach (var outboxMessage in toProcess)
+
+        var parallelOptions = new ParallelOptions
         {
-            if (ct.IsCancellationRequested)
-            {
-                _logger.LogDebug("Cancellation requested");
-                return;
-            }
-            
-            try
-            {
-                _logger.LogDebug("Processing outbox job {id}", outboxMessage.Id);
-                
-                var jobType = outboxMessage.GetJobType();
-                var job = new Job(jobType, outboxMessage.GetMethod(), outboxMessage.GetArguments().ToArray(), outboxMessage.Queue);
+            MaxDegreeOfParallelism = MaxDegreeOfParallelism,
+            CancellationToken = ct,
+        };
 
-                string jobId = null;
-                
-                if (outboxMessage.EnqueueAt.HasValue)
+        foreach (var chunk in toProcess.Chunk(ChunkSize))
+        {
+            await Parallel.ForEachAsync(chunk, parallelOptions, (outboxMessage, _) =>
+            {
+                try
                 {
-                    //schedule for specified date
-                    jobId = backgroundJobClient.Create(job, new ScheduledState(outboxMessage.EnqueueAt.Value.DateTime));
+                    var jobType = outboxMessage.GetJobType();
+                    var job = new Job(jobType, outboxMessage.GetMethod(), outboxMessage.GetArguments().ToArray(), outboxMessage.Queue);
+
+                    string jobId;
+
+                    if (outboxMessage.EnqueueAt.HasValue)
+                    {
+                        //schedule for specified date
+                        jobId = backgroundJobClient.Create(job, new ScheduledState(outboxMessage.EnqueueAt.Value.DateTime));
+                    }
+                    else if (outboxMessage.Delay.HasValue)
+                    {
+                        //schedule for specified delay
+                        jobId = backgroundJobClient.Create(job, new ScheduledState(outboxMessage.Delay.Value));
+                    }
+                    else
+                    {
+                        //enqueue now
+                        jobId = backgroundJobClient.Create(job, new EnqueuedState(outboxMessage.Queue));
+                    }
+
+                    outboxMessage.Processed = true;
+                    outboxMessage.HangfireJobId = jobId;
                 }
-                else if (outboxMessage.Delay.HasValue)
+                catch (Exception e)
                 {
-                    //schedule for specified delay
-                    jobId = backgroundJobClient.Create(job, new ScheduledState(outboxMessage.Delay.Value));
-                }
-                else
-                {
-                    //enqueue now
-                    jobId = backgroundJobClient.Create(job, new EnqueuedState(outboxMessage.Queue));
+                    _logger.LogError(e, "Unable to process outbox job {id}", outboxMessage.Id);
+                    outboxMessage.Exception = e.ToString();
                 }
 
-                outboxMessage.Processed = true;
-                outboxMessage.HangfireJobId = jobId;
-                
-                _logger.LogDebug("Successfully processed outbox job {id}", outboxMessage.Id);
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "Unable to process outbox job {id}", outboxMessage.Id);
-                outboxMessage.Exception = e.ToString();
-            }
+                return ValueTask.CompletedTask;
+            });
+
+            // Persist per chunk so a SaveChanges failure loses at most ChunkSize
+            // rows of "marked processed" state rather than the whole batch.
+            await dbContext.SaveChangesAsync(ct);
         }
-
-        _logger.LogDebug("Persisting outbox job changes");
-        await dbContext.SaveChangesAsync(ct);
     }
 }
 


### PR DESCRIPTION
### Changes

- Added optional pagination + ensured ordering before `Skip` (latest records first)
- Parallelized job creation (`backgroundJobClient.Create` is thread-safe)
- Added retry/backoff for background service errors
- Implemented chunking to limit duplication on crashes (max = `ChunkSize`)
- Use `PeriodicTimer` so the next interval is already in progress while the job is running